### PR TITLE
Feature/register value enum concat

### DIFF
--- a/include/nanolib/detail/RegisterValue.h
+++ b/include/nanolib/detail/RegisterValue.h
@@ -166,7 +166,7 @@ public:
     }
 
     static enum_t read() {
-        uint_t int_result = 0;
+        uint_t int_result  = 0;
         uint_t total_shift = 0;
 
         (read_val<register_vals_t>(int_result, total_shift), ...);
@@ -190,7 +190,7 @@ private:
     template <typename register_val_t>
     static void read_val(uint_t& int_value, uint_t& total_shift) {
         uint_t temp = register_val_t::read();
-        int_value = int_value + ( temp << total_shift);
+        int_value   = int_value + (temp << total_shift);
 
         total_shift += register_val_t::length;
     }

--- a/include/nanolib/detail/RegisterValue.h
+++ b/include/nanolib/detail/RegisterValue.h
@@ -180,8 +180,8 @@ private:
         int_value   = int_value >> register_val_t::length;
 
         constexpr uint_t mask =
-                periph_detail::get_bitmask_ones<uint_t,
-                        register_val_t::length>::value;
+            periph_detail::get_bitmask_ones<uint_t,
+                                            register_val_t::length>::value;
 
         register_val_t::write(temp & mask);
     }

--- a/include/nanolib/detail/RegisterValue.h
+++ b/include/nanolib/detail/RegisterValue.h
@@ -176,11 +176,13 @@ public:
 private:
     template <typename register_val_t>
     static void write_val(uint_t& int_value) {
-        constexpr uint_t mask =
-            periph_detail::get_bitmask_ones<uint_t,
-                                            register_val_t::length>::value;
         uint_t temp = int_value;
         int_value   = int_value >> register_val_t::length;
+
+        constexpr uint_t mask =
+                periph_detail::get_bitmask_ones<uint_t,
+                        register_val_t::length>::value;
+
         register_val_t::write(temp & mask);
     }
 

--- a/include/nanolib/detail/RegisterValue.h
+++ b/include/nanolib/detail/RegisterValue.h
@@ -64,7 +64,7 @@ protected:
     constexpr static uint8_t start_bit = t_start_bit;
     constexpr static uint8_t length    = t_length;
 
-    using uint_t = typename required_int_t<t_length>::type;
+    using uint_t = typename required_int_t<t_length + t_start_bit>::type;
 
     static volatile uint_t* get_addr_ptr() {
         return reinterpret_cast<volatile uint_t*>(t_register::address);

--- a/include/nanolib/detail/RegisterValue.h
+++ b/include/nanolib/detail/RegisterValue.h
@@ -56,7 +56,14 @@ struct required_int_t<
 
 template <typename t_register, uint8_t t_start_bit, uint8_t t_length>
 class RegisterValue {
+
+    template <typename enum_t, class, typename... register_vals_t>
+    friend class RegisterValueEnumConcat_impl;
+
 protected:
+    constexpr static uint8_t start_bit = t_start_bit;
+    constexpr static uint8_t length    = t_length;
+
     using uint_t = typename required_int_t<t_length>::type;
 
     static volatile uint_t* get_addr_ptr() {

--- a/include/nanolib/detail/RegisterValue.h
+++ b/include/nanolib/detail/RegisterValue.h
@@ -150,6 +150,14 @@ class RegisterValueEnumConcat_impl {
     using uint_t = typename required_int_t<get_val_length()>::type;
 
 public:
+    template <enum_t t_value>
+    static void write() {
+        static_assert(has_no_more_bits<static_cast<uint_t>(t_value), get_val_length()>::value,
+                      "More bits written to register value then it is long");
+
+        write(t_value);
+    }
+
     static void write(enum_t value) {
         uint_t int_value = static_cast<uint_t>(value);
 

--- a/include/nanolib/detail/RegisterValue.h
+++ b/include/nanolib/detail/RegisterValue.h
@@ -152,7 +152,8 @@ class RegisterValueEnumConcat_impl {
 public:
     template <enum_t t_value>
     static void write() {
-        static_assert(has_no_more_bits<static_cast<uint_t>(t_value), get_val_length()>::value,
+        static_assert(has_no_more_bits<static_cast<uint_t>(t_value),
+                                       get_val_length()>::value,
                       "More bits written to register value then it is long");
 
         write(t_value);
@@ -161,35 +162,31 @@ public:
     static void write(enum_t value) {
         uint_t int_value = static_cast<uint_t>(value);
 
-        (register_vals_t::write(
-             right_shift_delayed(int_value, register_vals_t::length) &
-             get_bitmask_ones<uint_t, register_vals_t::length>::value),
-         ...);
+        (write_val<register_vals_t>(int_value), ...);
     }
 
     static enum_t read() {
         uint_t int_result = 0;
 
         // TODO
-        //        (add_shifted(int_result, register_vals_t::read(),
-        //                     register_vals_t::length),
-        //         ...);
 
         return static_cast<enum_t>(int_result);
     }
 
 private:
-    // A utility function to shift a variable from wihtin an expression,
-    // while using the old value of the variable
-    static uint_t right_shift_delayed(uint_t& value, uint_t shift) {
-        uint_t result = value;
-        value         = result >> shift;
-        return result;
+    template <typename register_val_t>
+    static void write_val(uint_t& int_value) {
+        constexpr uint_t mask =
+            periph_detail::get_bitmask_ones<uint_t,
+                                            register_val_t::length>::value;
+        uint_t temp = int_value;
+        int_value   = int_value >> register_val_t::length;
+        register_val_t::write(temp & mask);
     }
 
-    static void add_shifted(uint_t& sum, uint_t value, uint_t shift) {
-        // TODO
-    }
+    //    static void add_shifted(uint_t& sum, uint_t value, uint_t shift) {
+    //        // TODO
+    //    }
 };
 
 

--- a/include/nanolib/detail/RegisterValue.h
+++ b/include/nanolib/detail/RegisterValue.h
@@ -167,8 +167,9 @@ public:
 
     static enum_t read() {
         uint_t int_result = 0;
+        uint_t total_shift = 0;
 
-        // TODO
+        (read_val<register_vals_t>(int_result, total_shift), ...);
 
         return static_cast<enum_t>(int_result);
     }
@@ -186,9 +187,13 @@ private:
         register_val_t::write(temp & mask);
     }
 
-    //    static void add_shifted(uint_t& sum, uint_t value, uint_t shift) {
-    //        // TODO
-    //    }
+    template <typename register_val_t>
+    static void read_val(uint_t& int_value, uint_t& total_shift) {
+        uint_t temp = register_val_t::read();
+        int_value = int_value + ( temp << total_shift);
+
+        total_shift += register_val_t::length;
+    }
 };
 
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -42,4 +42,5 @@ macro(package_add_test TESTNAME)
 endmacro()
 
 package_add_test(RegisterValue src/register_value.cpp)
+package_add_test(RegisterValueEnumConcat src/register_value_enum_concat.cpp)
 package_add_test(ConstUtil src/const_util.cpp)

--- a/test/src/register_value_enum_concat.cpp
+++ b/test/src/register_value_enum_concat.cpp
@@ -1,4 +1,131 @@
-//
-// Created by andreas on 1/26/22.
-//
+#include <gtest/gtest.h>
+#include <nanolib/detail/RegisterValue.h>
 
+
+using namespace periph::periph_detail;
+
+
+namespace {
+
+
+/*
+ *
+ * Emulate the hardware registers with simple buffers
+ *
+ */
+
+
+uint8_t REG1_buffer[2] = {0};
+uint8_t REG2_buffer[2] = {0};
+uint8_t REG3_buffer[2] = {0};
+
+struct register_set {
+    struct REG1 {
+        static std::size_t address;
+        using VAL1 = RegisterValue<REG1, 0, 8>;
+        using VAL2 = RegisterValue<REG1, 0, 4>;
+    };
+
+    struct REG2 {
+        static std::size_t address;
+        using VAL1 = RegisterValue<REG2, 0, 4>;
+        using VAL2 = RegisterValue<REG2, 4, 3>;
+    };
+
+    struct REG3 {
+        static std::size_t address;
+        using VAL1 = RegisterValue<REG3, 0, 2>;
+        using VAL2 = RegisterValue<REG3, 2, 9>;
+        using VAL3 = RegisterValue<REG3, 11, 5>;
+    };
+
+    enum class ConcatValue { A = 0b1111'1111, B, C, D, E, F};
+
+    using CONCAT_VAL1 =
+        RegisterValueEnumConcat<ConcatValue, REG1::VAL1, REG2::VAL2, REG3::VAL3>;
+    using CONCAT_VAL2 = RegisterValueEnumConcat<ConcatValue, REG3::VAL1, REG3::VAL2>;
+    using CONCAT_VAL3 = RegisterValueEnumConcat<ConcatValue, REG3::VAL1, REG1::VAL2>;
+    using CONCAT_VAL4 = RegisterValueEnumConcat<ConcatValue, REG3::VAL1>;
+};
+
+std::size_t register_set::REG1::address =
+    reinterpret_cast<std::size_t>(&REG1_buffer);
+std::size_t register_set::REG2::address =
+    reinterpret_cast<std::size_t>(&REG2_buffer);
+std::size_t register_set::REG3::address =
+    reinterpret_cast<std::size_t>(&REG3_buffer);
+
+
+/*
+ *
+ * Actual tests
+ *
+ */
+
+
+TEST(RegisterValueEnumConcat, write_basic) {
+    constexpr uint8_t  val1 = 0b01010101u;
+    constexpr uint8_t  val2 = 0b1101u;
+    constexpr uint8_t  val3 = 0b0111u;
+    constexpr uint16_t val4 = 0b11110000'10011111u;
+
+    for (auto& elem : REG1_buffer)
+        elem = 0b10111010u;
+    for (auto& elem : REG2_buffer)
+        elem = 0b10101111u;
+    for (auto& elem : REG3_buffer)
+        elem = 0b11100011u;
+
+    //register_set::CONCAT_VAL1::write(register_set::ConcatValue::A);
+    register_set::CONCAT_VAL4::write<register_set::ConcatValue::A>();
+
+//    register_set::REG1::VAL1::write<val1>();
+//    EXPECT_EQ(REG1_buffer[0], val1);
+//
+//    register_set::REG2::VAL1::write<val2>();
+//    register_set::REG2::VAL2::write<val3>();
+//    EXPECT_EQ(REG2_buffer[0], val2 | (val3 << 4));
+//
+//    register_set::REG3::VAL1::write<val4>();
+//    uint16_t reg_value = *(reinterpret_cast<uint16_t*>(REG3_buffer));
+//    EXPECT_EQ(reg_value, val4);
+}
+
+TEST(RegisterValueEnumConcat, write_no_overflow) {
+    constexpr uint8_t val1 = 0b01010101u;
+    constexpr uint8_t val2 = 0b1101u;
+    constexpr uint8_t val3 = 0b0111u;
+
+    for (auto& elem : REG1_buffer)
+        elem = 0b11111111u;
+    for (auto& elem : REG2_buffer)
+        elem = 0b11111111u;
+    for (auto& elem : REG3_buffer)
+        elem = 0b11111111u;
+
+//    register_set::REG1::VAL1::write<val1>();
+//    EXPECT_EQ(REG1_buffer[1], 0b11111111u);
+//
+//    register_set::REG2::VAL1::write<val2>();
+//    register_set::REG2::VAL2::write<val3>();
+//    EXPECT_EQ(REG2_buffer[1], 0b11111111u);
+//
+//    register_set::REG3::VAL1 ::write<val3>();
+//    EXPECT_EQ(REG3_buffer[1], 0);
+}
+
+TEST(RegisterValueEnumConcat, read_basic) {
+//    *(reinterpret_cast<uint16_t*>(REG1_buffer)) = 0b001100'11110000u;
+//    EXPECT_EQ(REG1_buffer[0], register_set::REG1::VAL1::read());
+//
+//    *(reinterpret_cast<uint16_t*>(REG2_buffer)) = 0b000001'00001000u;
+//    EXPECT_EQ(REG2_buffer[0] & 0b00001111u, register_set::REG2::VAL1::read());
+//    EXPECT_EQ(REG2_buffer[0] & 0b11110000u, register_set::REG2::VAL2::read());
+//
+//    *(reinterpret_cast<uint16_t*>(REG3_buffer)) = 0b000000'10001111u;
+//    EXPECT_EQ(*(reinterpret_cast<uint16_t*>(REG3_buffer)),
+//              register_set::REG3::VAL1::read());
+}
+
+
+} // namespace

--- a/test/src/register_value_enum_concat.cpp
+++ b/test/src/register_value_enum_concat.cpp
@@ -43,7 +43,9 @@ struct register_set {
         A = 0b1111'1111'1111'1111,
         B = 0b1000'1101'1100'0011,
         C = 0b0000'0001'0000'1110,
-        D = 0b0000'0001'0010'1111
+        D = 0b0000'0001'0010'1111,
+        E = 0b0000'0111'1111'1111,
+        F = 0b0000'0000'0011'1111
     };
 
     // clang-format off
@@ -126,21 +128,36 @@ TEST(RegisterValueEnumConcat, write_basic) {
 
 TEST(RegisterValueEnumConcat, write_no_overflow) {
     for (auto& elem : REG1_buffer)
-        elem = 0b11111111u;
+        elem = 0b00000000u;
     for (auto& elem : REG2_buffer)
-        elem = 0b11111111u;
+        elem = 0b00000000u;
     for (auto& elem : REG3_buffer)
-        elem = 0b11111111u;
+        elem = 0b00000000u;
 
-    //    register_set::REG1::VAL1::write<val1>();
-    //    EXPECT_EQ(REG1_buffer[1], 0b11111111u);
-    //
-    //    register_set::REG2::VAL1::write<val2>();
-    //    register_set::REG2::VAL2::write<val3>();
-    //    EXPECT_EQ(REG2_buffer[1], 0b11111111u);
-    //
-    //    register_set::REG3::VAL1 ::write<val3>();
-    //    EXPECT_EQ(REG3_buffer[1], 0);
+    register_set::CONCAT_VAL1::write<register_set::ConcatValue::A>();
+    EXPECT_EQ(REG1_buffer[1], 0);
+    EXPECT_EQ((REG2_buffer[0] & get_bitmask_ones<uint8_t, 4>::value), 0);
+    EXPECT_EQ((REG2_buffer[0] >> 7), 0);
+    EXPECT_EQ(REG3_buffer[0], 0);
+    EXPECT_EQ((REG3_buffer[1] & get_bitmask_ones<uint8_t, 3>::value), 0);
+
+
+    for (auto& elem : REG3_buffer)
+        elem = 0b00000000u;
+
+    register_set::CONCAT_VAL2::write<register_set::ConcatValue::E>();
+    EXPECT_EQ(REG3_buffer[1] >> 3, 0);
+
+
+    for (auto& elem : REG1_buffer)
+        elem = 0b00000000u;
+    for (auto& elem : REG3_buffer)
+        elem = 0b00000000u;
+
+    register_set::CONCAT_VAL3::write<register_set::ConcatValue::F>();
+    EXPECT_EQ(REG3_buffer[0] >> 2, 0);
+    EXPECT_EQ(REG1_buffer[0], 0);
+    EXPECT_EQ(REG1_buffer[1] >> 4, 0);
 }
 
 TEST(RegisterValueEnumConcat, read_basic) {

--- a/test/src/register_value_enum_concat.cpp
+++ b/test/src/register_value_enum_concat.cpp
@@ -1,0 +1,4 @@
+//
+// Created by andreas on 1/26/22.
+//
+

--- a/test/src/register_value_enum_concat.cpp
+++ b/test/src/register_value_enum_concat.cpp
@@ -40,12 +40,12 @@ struct register_set {
     };
 
     enum class ConcatValue {
-        A = 0b1111'1111'1111'1111,
-        B = 0b1000'1101'1100'0011,
-        C = 0b0000'0001'0000'1110,
-        D = 0b0000'0001'0010'1111,
-        E = 0b0000'0111'1111'1111,
-        F = 0b0000'0000'0011'1111
+        A = 0b1111'1111'1111'1111u,
+        B = 0b1000'1101'1100'0011u,
+        C = 0b0000'0001'0000'1110u,
+        D = 0b0000'0001'0010'1111u,
+        E = 0b0000'0111'1111'1111u,
+        F = 0b0000'0000'0011'1111u
     };
 
     // clang-format off
@@ -161,17 +161,18 @@ TEST(RegisterValueEnumConcat, write_no_overflow) {
 }
 
 TEST(RegisterValueEnumConcat, read_basic) {
-    //    *(reinterpret_cast<uint16_t*>(REG1_buffer)) = 0b001100'11110000u;
-    //    EXPECT_EQ(REG1_buffer[0], register_set::REG1::VAL1::read());
-    //
-    //    *(reinterpret_cast<uint16_t*>(REG2_buffer)) = 0b000001'00001000u;
-    //    EXPECT_EQ(REG2_buffer[0] & 0b00001111u,
-    //    register_set::REG2::VAL1::read()); EXPECT_EQ(REG2_buffer[0] &
-    //    0b11110000u, register_set::REG2::VAL2::read());
-    //
-    //    *(reinterpret_cast<uint16_t*>(REG3_buffer)) = 0b000000'10001111u;
-    //    EXPECT_EQ(*(reinterpret_cast<uint16_t*>(REG3_buffer)),
-    //              register_set::REG3::VAL1::read());
+    *(reinterpret_cast<uint16_t*>(REG1_buffer)) = 0b00000000'11111111u;
+    *(reinterpret_cast<uint16_t*>(REG2_buffer)) = 0b00000000'01110000u;
+    *(reinterpret_cast<uint16_t*>(REG3_buffer)) = 0b11111000'00000000u;
+    EXPECT_EQ(register_set::CONCAT_VAL1::read(), register_set::ConcatValue::A);
+
+    *(reinterpret_cast<uint16_t*>(REG1_buffer)) = 0b11111111'11000011u;
+    *(reinterpret_cast<uint16_t*>(REG2_buffer)) = 0b11111111'11011111u;
+    *(reinterpret_cast<uint16_t*>(REG3_buffer)) = 0b10001111'11111111u;
+    EXPECT_EQ(register_set::CONCAT_VAL1::read(), register_set::ConcatValue::B);
+
+    *(reinterpret_cast<uint16_t*>(REG3_buffer)) = 0b001'00001110u;
+    EXPECT_EQ(register_set::CONCAT_VAL2::read(), register_set::ConcatValue::C);
 }
 
 

--- a/test/src/register_value_enum_concat.cpp
+++ b/test/src/register_value_enum_concat.cpp
@@ -108,7 +108,8 @@ TEST(RegisterValueEnumConcat, write_basic) {
 
     register_set::CONCAT_VAL2::write<register_set::ConcatValue::C>();
     EXPECT_EQ(REG3_buffer[0], (C_v & get_bitmask_ones<uint8_t, 8>::value));
-    EXPECT_EQ(REG3_buffer[1], ((C_v >> 8) & get_bitmask_ones<uint8_t, 1>::value));
+    EXPECT_EQ(REG3_buffer[1],
+              ((C_v >> 8) & get_bitmask_ones<uint8_t, 1>::value));
 
 
     for (auto& elem : REG3_buffer)
@@ -119,7 +120,8 @@ TEST(RegisterValueEnumConcat, write_basic) {
 
     register_set::CONCAT_VAL3::write<register_set::ConcatValue::D>();
     EXPECT_EQ(REG3_buffer[0], (D_v & get_bitmask_ones<uint8_t, 2>::value));
-    EXPECT_EQ((REG1_buffer[1]), ((D_v >> 2) & get_bitmask_ones<uint8_t, 4>::value));
+    EXPECT_EQ((REG1_buffer[1]),
+              ((D_v >> 2) & get_bitmask_ones<uint8_t, 4>::value));
 }
 
 TEST(RegisterValueEnumConcat, write_no_overflow) {


### PR DESCRIPTION
Added RegisterValueEnumConcat type, which allows writing to concatenated RegisterValues as if they were one, using an enum to set the value to be written
